### PR TITLE
Use platform agnostic path seperator

### DIFF
--- a/src/components/SDCardPage.vue
+++ b/src/components/SDCardPage.vue
@@ -334,7 +334,7 @@ export default {
       zipEntries.forEach(function (zipEntry) {
           var xpath = path.join(sddir, zipEntry.entryName.substring(zipEntry.entryName.indexOf('/') + 1));
           if (!zipEntry.isDirectory) {
-            xpath = xpath.substring(0, xpath.lastIndexOf("/"))
+            xpath = xpath.substring(0, xpath.lastIndexOf(path.sep))
           }
 
           zip.extractEntryTo(zipEntry.entryName, xpath, false, /*overwrite*/ true);


### PR DESCRIPTION
As soon as you used path.join, correct path separators were used, rendering the substring trim invalid on Windows. The forward slash is still valid when processing the zip file because it is being generated on a linux host.