### PR TITLE
Preserve the EEPROM folder if present

### DIFF
--- a/src/components/SDCardPage.vue
+++ b/src/components/SDCardPage.vue
@@ -230,7 +230,7 @@ export default {
           files.forEach(function(filename) {
             if (fs.statSync(pathx + "/" + filename).isDirectory()) {
               try {
-                if ((filename != "RADIO") && (filename != "MODELS")) {
+                if ((filename != "RADIO") && (filename != "MODELS") && (filename != "EEPROM")) {
                   self.removeDir(path.join(pathx, filename))
                   fs.rmdirSync(path.join(pathx, filename), { recursive: true });
                 }


### PR DESCRIPTION
Preserve the backup folder created on transmitter that store models in EEPROM

e.g. T-Lite