### PR TITLE
Update SD card eraseure warning

### DIFF
--- a/src/components/SDCardPage.vue
+++ b/src/components/SDCardPage.vue
@@ -56,7 +56,7 @@
             <v-expansion-panel>
               <v-expansion-panel-header>Select Disk</v-expansion-panel-header>
               <v-expansion-panel-content>
-                  <p>Please select the SD Card that you wish to write to. The SD card <span style="text-decoration:underline; color: red">will be erased</span> (except for model and radio settings) unless you untick the Erase option below, so make sure to select the correct one!</p>
+                  <p>Please select the drive letter for your SD Card. The SD card <span style="text-decoration:underline; color: red">will be erased</span> (except for model and radio settings) unless you untick the Erase option below, so make sure to select the correct one!</p>
 
                   <v-select
                     :items="disks"

--- a/src/components/SDCardPage.vue
+++ b/src/components/SDCardPage.vue
@@ -56,7 +56,7 @@
             <v-expansion-panel>
               <v-expansion-panel-header>Select Disk</v-expansion-panel-header>
               <v-expansion-panel-content>
-                  <p>Please select the SD Card you want to write, please note if the checkbox below is enabled this will overwrite all contents of the disk so make sure to select the correct one.</p>
+                  <p>Please select the SD Card that you wish to write to. The SD card <span style="text-decoration:underline; color: red">will be erased</span> (except for model and radio settings) unless you untick the Erase option below, so make sure to select the correct one!</p>
 
                   <v-select
                     :items="disks"


### PR DESCRIPTION
Make it look a bit more scary to ensure it's read ;)

We should probably also discuss a better default or highlighting reason for selecting or unselecting to user at some point... 

The problem being that if you run Flasher without changing the defaults, it would blow away any custom model images, widgets, scripts and sounds. 

i.e. two radio buttons would work  - saying something like 
```
(*) Don't Erase (updating existing card)
( ) Erase (delete drive contents)
```

Or is `[x] Erase Disk before Flashing (uncheck if updating)` enough? 


Dark:
![image](https://user-images.githubusercontent.com/5500713/125547264-f721f450-0734-445a-98bc-868da6c39965.png)

Light:
![image](https://user-images.githubusercontent.com/5500713/125547235-9ee4d64f-8f5b-4944-a126-e1cc0bf385ed.png)

