### PR TITLE
Make button sizes percentages rather than fixed px

### DIFF
--- a/src/components/FlasherPage.vue
+++ b/src/components/FlasherPage.vue
@@ -81,7 +81,6 @@
                 :disabled="noPopulatedInfo"
             >Flash Radio Firmware</v-btn>
 
-            <td class="text-xs-right fill-width buttons-cell">
                 <v-btn
                     class="mt-4 mr-2"
                     color="primary"
@@ -89,7 +88,7 @@
                     large
                     @click="saveFw"
                     :disabled="noPopulatedInfo"
-                    :width="274"
+                    :width="49+'%'"
                 >Save to File</v-btn>
 
                 <v-btn
@@ -98,9 +97,8 @@
                     elevation="2"
                     large
                     @click="flashLocalFw"
-                    :width="274"
+                    :width="49+'%'"
                 >Flash Local File</v-btn>
-            </td>
           </div>
 
         </div>


### PR DESCRIPTION
Prevents any OS variations in size and rendering from breaking due to arbitrary pixel values...

49% was chosen as 50% will still play up, probably due to padding. 

This is the result on Windows 10:
![image](https://user-images.githubusercontent.com/5500713/129890190-220c2555-0178-440a-b162-b10b525c9055.png)
