### PR TITLE
Simple mode - look in subfolder of nightly zips

### DIFF
--- a/src/support/fw-branch.js
+++ b/src/support/fw-branch.js
@@ -59,7 +59,7 @@ async function downloadFwRelease(firmwareFile, bdurl) {
     var bufferFW;
 
     zipEntries.forEach((entry) => {
-        if (entry.entryName.startsWith(firmwareFile)) {
+        if (entry.entryName.startsWith(firmwareFile) || entry.entryName.startsWith("edgetx-firmware-nightly/"+firmwareFile)) {
             bufferFW = entry.getData()
         }
     });
@@ -109,7 +109,7 @@ async function downloadReleaseMetadata(bdurl) {
     console.log("Loading zip entries...");
 
     zipEntries.forEach((entry) => {
-        if (entry.entryName == "fw.json") {
+        if (entry.entryName == "fw.json" || entry.entryName == "edgetx-firmware-nightly/fw.json") {
             indexdata = JSON.parse(entry.getData().toString('utf8'));
         }
     });


### PR DESCRIPTION
Resolves #18 

Nightly zip files have a subfolder, so look in the subfolder for json and firmware files. I've only tested this for save file functionality at present, ~~write to radio/DFU could still be broken~~. Also tested DFU write to radio, just finished downloading a nightly to the radio in 'simple' mode! :)