### PR TITLE
Make 'releases' ignore RCs

### DIFF
--- a/src/components/FlasherPage.vue
+++ b/src/components/FlasherPage.vue
@@ -521,6 +521,10 @@ export default {
         var ltimestamp = tags[0].created_at;
 
         tags.forEach(await (async function (item) {
+          if (item.tag_name.match(new RegExp(".*RC\\d+","i"))) {
+            return;
+          }
+
           ltimestamp = (new Date(ltimestamp.created_at) < new Date(item.created_at)) ? item : ltimestamp;
 
           self.fwversions.push({


### PR DESCRIPTION
Will prevent any tag_name from being added to the list if it contains "RC" followed by numbers and is case insensitive.

Following up on the hint I gave in https://github.com/EdgeTX/flasher/issues/16#issuecomment-887076528