### PR TITLE
Show version from `package.json`

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -66,7 +66,7 @@
       </v-main>
   
       <v-footer app>
-        <span>&copy; {{ new Date().getFullYear() }} Ari Stehney, EdgeTX Team {{ getGitString() }}</span>
+        <span>&copy; {{ new Date().getFullYear() }} Ari Stehney, EdgeTX Team - Version {{appVersion}}</span>
       </v-footer>
     </v-app>
 </template>
@@ -84,12 +84,14 @@
 const fs = require('fs');
 const path = require('path');
 const {remote} = require("electron");
+import {version} from '../package.json'
 
 export default {
   name: 'EdgeTX-Flasher',
 
   data: () => ({
-    gitcommit: ""
+    gitcommit: "",
+    appVersion:version
   }),
 
   methods: {


### PR DESCRIPTION
I don't know if this works for your workflow... but it looks like this is one way to get the version to display - from the package.json.

Then you could either run `npm version patch` before pushing a commit (or `minor` / `major` as needed), or use a pre-commit hook so that git will do it automatically. It looks like it also survives the package being built, as it shows on a built windows package. Or I guess even have the github action somehow do that, then it really can't be forgotten!

Just another approach - a timestamp or even git commit hash would be fine, but it doesn't seem to want to co-operate atm. 

![image](https://user-images.githubusercontent.com/5500713/130737020-45eabfa6-c3a9-43b8-b476-4857850d1822.png)
