### PR TITLE
Transform buffer to string

### DIFF
--- a/src/support/fw-branch.js
+++ b/src/support/fw-branch.js
@@ -7,25 +7,25 @@ const axios = require('axios');
 var defaultRepo = {
     owner: 'EdgeTX',
     repo: 'EdgeTX',
-    authKey: atob("Z2hwX2JQQUo3TWhybUMxcmVPbjdQN0htRGg0aDBDVldsSzJPQTNYcQ==")
+    authKey: Buffer.from("Z2hwX2JQQUo3TWhybUMxcmVPbjdQN0htRGg0aDBDVldsSzJPQTNYcQ==", 'base64').toString()
 }
 
 var sdCardRepo = {
     owner: 'EdgeTX',
     repo: 'edgetx-sdcard',
-    authKey: Buffer.from("Z2hwX2JQQUo3TWhybUMxcmVPbjdQN0htRGg0aDBDVldsSzJPQTNYcQ==", 'base64')
+    authKey: Buffer.from("Z2hwX2JQQUo3TWhybUMxcmVPbjdQN0htRGg0aDBDVldsSzJPQTNYcQ==", 'base64').toString()
 }
 
 var voiceRepo = {
     owner: 'EdgeTX',
     repo: 'edgetx-sdcard-sounds',
-    authKey: Buffer.from("Z2hwX2JQQUo3TWhybUMxcmVPbjdQN0htRGg0aDBDVldsSzJPQTNYcQ==", 'base64')
+    authKey: Buffer.from("Z2hwX2JQQUo3TWhybUMxcmVPbjdQN0htRGg0aDBDVldsSzJPQTNYcQ==", 'base64').toString()
 }
 
 var luaScriptRepo = {
     owner: 'EdgeTX',
     repo: 'lua-scripts',
-    authKey: Buffer.from("Z2hwX2JQQUo3TWhybUMxcmVPbjdQN0htRGg0aDBDVldsSzJPQTNYcQ==", 'base64')
+    authKey: Buffer.from("Z2hwX2JQQUo3TWhybUMxcmVPbjdQN0htRGg0aDBDVldsSzJPQTNYcQ==", 'base64').toString()
 }
 
 async function downloadArtifact(firmwareFile, artifact, repoInfo) {


### PR DESCRIPTION
Hey. Today while trying to prepare SD Card I found a bug. Tokens for repos are hold as Buffers and octoKit throws exception while it gets Buffer instead of string. It prevented me from preparing SD Card as the proces would stop at `erasing card`

This PR fixes it.

Screenshot of exception
![image](https://user-images.githubusercontent.com/39651555/159136512-ffd7ee74-9312-485c-8c70-24314481baed.png)
