### PR TITLE
fix: properly key language checkboxes and fix error when extracting language packs

### DIFF
--- a/src/components/SDCardPage.vue
+++ b/src/components/SDCardPage.vue
@@ -49,7 +49,7 @@
                         <v-checkbox 
                           multiple
                           :key="item.filename"
-                          :value="item.filename"
+                          :value="item"
                           :hide-details="true"
                           v-model="voiceSelect"
                         />

--- a/src/components/SDCardPage.vue
+++ b/src/components/SDCardPage.vue
@@ -479,7 +479,7 @@ export default {
         var voiceurls = voicereleases.filter(obj => {
           return obj.tag_name == "latest"
         })[0].assets.filter(obj => {
-          return self.voiceSelect.some(v => obj.name.includes(v.toLowerCase()))
+          return self.voiceSelect.some(v => obj.name.includes(v.directory.toLowerCase()))
         });
 
         self.message += "Downloading and decompressing all sound packs...<br><br>";


### PR DESCRIPTION
Addresses #47 and #48. Fixes all checkboxes checking themselves when selecting language packs, and fixes an error when finding language pack zips that prevented language packs and scripts from being copied to the SD card correctly.